### PR TITLE
Fixed endings of various types

### DIFF
--- a/DecompEigToPSDConstruction.m
+++ b/DecompEigToPSDConstruction.m
@@ -512,3 +512,5 @@ else
         Y{j} = NaN;
     end
 end
+
+end

--- a/DecompEigToPSDConstruction.m
+++ b/DecompEigToPSDConstruction.m
@@ -1,4 +1,4 @@
-%%  DecompEigToPSDConstruction
+﻿%%  DecompEigToPSDConstruction
 %   Uses semidefinite programming to implement Theorem 4 of the paper, and
 %   thus shows that certain sets of numbers cannot be spectra of
 %   decomposable symmetric entanglement witnesses.
@@ -514,3 +514,4 @@ else
 end
 
 end
+

--- a/DecompWitConstruction.m
+++ b/DecompWitConstruction.m
@@ -83,3 +83,5 @@ if strcmp(cvx_status, 'Failed')
 else
     c = 1/coef;
 end
+
+end

--- a/DecompWitConstruction.m
+++ b/DecompWitConstruction.m
@@ -1,4 +1,4 @@
-%%  DecompWitConstruction
+﻿%%  DecompWitConstruction
 %   Determines whether or not there exists a decomposable symmetric
 %   entanglement witness with the maximal number (d(d-1)/2) of negative
 %   eigenvalues.
@@ -85,3 +85,4 @@ else
 end
 
 end
+

--- a/YEigIneqD3.m
+++ b/YEigIneqD3.m
@@ -44,3 +44,5 @@ else
     pos = false;
     Y = NaN;
 end
+
+end

--- a/YEigIneqD3.m
+++ b/YEigIneqD3.m
@@ -1,4 +1,4 @@
-%%  YEigIneqD3
+﻿%%  YEigIneqD3
 %   Determines whether or not there exists a positive semidefinite matrix Y
 %   such that several inequalities are obeyed, as specified in Theorem 5 of
 %   the paper.
@@ -46,3 +46,4 @@ else
 end
 
 end
+


### PR DESCRIPTION
Added 'end' keywords to the ends of files to close the function definitions and removed the random ^M end of line characters.